### PR TITLE
Use issue import API and other formatting improvements

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -98,16 +98,21 @@ def format_name(issue):
 
 def format_body(options, issue):
     content = clean_body(issue.get('content'))
-    return u"""{}
+    return u"""Originally reported by: **{reporter}**
 
-{}
-- Bitbucket: https://bitbucket.org/{}/{}/issue/{}
-- Originally reported by: **{}**
+{sep}
+
+{content}
+
+{sep}
+- Bitbucket: https://bitbucket.org/{user}/{repo}/issue/{id}
 """.format(
-        content,
-        '-' * 40,
-        options.bitbucket_username, options.bitbucket_repo, issue['local_id'],
-        format_name(issue),
+        reporter=format_name(issue),
+        sep='-' * 40,
+        content=content,
+        user=options.bitbucket_username,
+        repo=options.bitbucket_repo,
+        id=issue['local_id'],
     )
 
 

--- a/migrate.py
+++ b/migrate.py
@@ -124,7 +124,7 @@ def format_comment(comment):
 """.format(
         comment['user'],
         '-' * 40,
-        comment['body'],
+        clean_comment(comment['body']),
     )
 
 
@@ -164,7 +164,29 @@ def clean_body(body):
                 lines.append("    " + line)
             else:
                 lines.append(line.replace("{{{", "`").replace("}}}", "`"))
-    return "\n".join(lines)
+
+    clean_changesets(lines)
+    return u"\n".join(lines)
+
+
+def clean_comment(body):
+    lines = body.splitlines()
+    clean_changesets(lines)
+    return u"\n".join(lines)
+
+
+def clean_changesets(lines):
+    """
+    Clean changeset references like:
+
+        → <<cset 22f3981d50c8>>'
+
+    Since they point to mercurial changesets and there's no easy way to map them
+    to git hashes, better to remove them altogether.
+    """
+    for index, line in reversed(list(enumerate(lines))):
+        if line.startswith(u'→ <<cset'):
+            lines.pop(index)
 
 
 # Bitbucket fetch

--- a/migrate.py
+++ b/migrate.py
@@ -77,11 +77,13 @@ def format_user(author_info):
         result = u" ".join([author_info['first_name'], author_info['last_name']])
 
     if author_info and 'username' in author_info:
-        link = '[{0}](http://bitbucket.org/{0})'.format(author_info['username'])
+        link1 = '[{0}](http://bitbucket.org/{0})'.format(author_info['username'])
+        link2 = '[{0}](http://github.com/{0})'.format(author_info['username'])
+        links = 'BitBucket: {}, GitHub: {}'.format(link1, link2)
         if result:
-            result += ' ({})'.format(link)
+            result += ' ({})'.format(links)
         else:
-            result = link
+            result = links
 
     if not result:
         result = "Anonymous"


### PR DESCRIPTION
Hi,

Recently we migrated [pytest](https://github.com/pytest-dev/pytest) from BitBucket and used your script, thanks for writing it and making it public!

I changed the requests to use the new [import API](https://gist.github.com/jonmagic/5282384165e0f86ef105) because I was hitting the HTTP limit after migrating a few issues. 

This PR includes a few other adjustments:
* Preserve the original date of creation for issues and comments (thanks to the new import API);
* Fix an encoding issue when a comment contains non-ascii characters;
* Change "Originally reported by" from footer to a header;
* Remove references to Hg changesets from comment bodies;
* Change explicit links in comments to relative links;
* When mentioning an user, add a link to its GitHub's profile as well;
* Add original `kind` and `component` as GitHub labels;