### PR TITLE
Invoke format_comment even in dry run. Fixes #20.

### DIFF
--- a/migrate.py
+++ b/migrate.py
@@ -343,7 +343,7 @@ if __name__ == "__main__":
             print u"Body: {}".format(
                 format_body(options, issue)
             )
-            print u"Comments", [comment['body'].encode('utf-8', errors='replace') for comment in comments]
+            print u"Comments", [format_comment(options, comment['body'].encode('utf-8', errors='replace')) for comment in comments]
         else:
             body = format_body(options, issue)
             push_issue(auth, gh_username, gh_repository, issue, body,


### PR DESCRIPTION
I haven't tested this change, but the idea is basically to invoke the comment formatting during the dry run.